### PR TITLE
feat: 일정 관리 UI 개선 및 FullCalendar 연동 로직 추가

### DIFF
--- a/service/src/main/java/edu/sm/controller/CalendarController.java
+++ b/service/src/main/java/edu/sm/controller/CalendarController.java
@@ -58,7 +58,7 @@ public class CalendarController {
         }
         log.info("User ID: {}", userId);
 
-        List<Schedule> schedules = calendarService.getSchedulesByUserId(userId);
+        List<Schedule> schedules = calendarService.getSchedulesByCwId(userId);
         try {
             // ObjectMapper 생성 및 JavaTimeModule 등록
             ObjectMapper objectMapper = new ObjectMapper();
@@ -75,7 +75,7 @@ public class CalendarController {
         }
 
 
-        model.addAttribute("center", dir + "calendar");
+        model.addAttribute("center", dir + "calendarCW");
         return "index";
     }
 }

--- a/service/src/main/java/edu/sm/controller/api/CalendarApiController.java
+++ b/service/src/main/java/edu/sm/controller/api/CalendarApiController.java
@@ -45,7 +45,7 @@ public class CalendarApiController {
     @PostMapping("/saveCareworkerSchedule")
     public ResponseDto<String> saveCareworkerSchedule(@RequestBody Schedule schedule, HttpSession session) {
         try {
-            Integer cwId = (Integer) session.getAttribute("cwId");
+            Integer cwId = (Integer) session.getAttribute("principal");
             if (cwId == null) {
                 throw new Exception("유효한 보호사 정보가 없습니다.");
             }

--- a/service/src/main/webapp/views/calendar/calendarCW.jsp
+++ b/service/src/main/webapp/views/calendar/calendarCW.jsp
@@ -8,7 +8,6 @@
     }
 </style>
 
-
 <div class="content-body">
     <div class="container-fluid">
         <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-top: 20px;">
@@ -109,6 +108,14 @@
                         }
                     };
                 }),
+            select: function(arg) {
+                const adjustedEndDate = new Date(arg.end);
+                adjustedEndDate.setDate(adjustedEndDate.getDate());
+
+                document.getElementById('modalAddStartDate').value = arg.startStr;
+                document.getElementById('modalAddEndDate').value = adjustedEndDate.toISOString().slice(0, 10);
+                $('#scheduleAddModal').modal('show');
+            },
             eventClick: function(info) {
                 console.log("Clicked event:", info.event);
                 console.log("Extended props:", info.event.extendedProps);
@@ -119,15 +126,6 @@
                     (info.event.start ? info.event.start.toLocaleDateString('ko-KR') : '-'); // 로컬 날짜만 표시
                 document.getElementById('scheduleEndDatetime').textContent =
                     (info.event.end ? info.event.end.toLocaleDateString('ko-KR') : '-'); // 로컬 날짜만 표시
-            },
-            select: function(arg) {
-                // 종료 날짜 설정
-                const adjustedEndDate = new Date(arg.end);
-                adjustedEndDate.setDate(adjustedEndDate.getDate());
-
-                document.getElementById('modalAddStartDate').value = arg.startStr;
-                document.getElementById('modalAddEndDate').value = adjustedEndDate.toISOString().slice(0, 10);
-                $('#scheduleAddModal').modal('show');
             },
             editable: true,
             dayMaxEvents: true
@@ -146,7 +144,6 @@
                 return;
             }
 
-            // 하드코딩된 시간 추가
             const startDateTime = startDate + "T13:13:00";
             const endDateTime = endDate + "T13:13:00";
 
@@ -158,7 +155,7 @@
             };
 
             $.ajax({
-                url: '/api/calendar/saveUserSchedule',
+                url: '/api/calendar/saveCareworkerSchedule',
                 method: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify(scheduleData),
@@ -179,5 +176,7 @@
             });
         });
     });
+
+
 </script>
 


### PR DESCRIPTION
- 일정 상세보기 패널 추가: 선택한 일정의 제목, 설명, 시작/종료 날짜를 표시
- 일정 목록에서 `CANCELLED` 상태의 일정은 제외하도록 필터링 추가
- `calendar.jsp` 및 `calendarCW.jsp`:
  - FullCalendar 이벤트 색상 및 스타일 설정 (`WAITING`, `ACTIVE` 상태에 따라 색상 변경)
  - 일정 상세 정보 표시용 패널 UI 추가
- FullCalendar 이벤트 로직 개선:
  - 선택한 날짜 범위를 기본적으로 `종일(all-day)`로 설정
  - 이벤트 클릭 시 상세 정보 표시 기능 추가
- 추가 모달 개선:
  - 시작/종료 시간 필드 제거, 하드코딩된 시간(`13:13:00`)으로 설정
- `CalendarApiController` 수정: 보호사 ID 세션 정보 변경 (`principal` 기반으로 보호사 정보 조회)
- 일정 저장 API 연동 (`/api/calendar/saveCareworkerSchedule`):
  - AJAX를 통해 서버로 일정 데이터 전송
  - 성공 시 FullCalendar에 새로운 이벤트 동적으로 추가